### PR TITLE
Revert mapping

### DIFF
--- a/config/xml/zfcuser/ZfcUser.Entity.User.dcm.xml
+++ b/config/xml/zfcuser/ZfcUser.Entity.User.dcm.xml
@@ -6,7 +6,7 @@
 
     <mapped-superclass name="ZfcUser\Entity\User" table="user">
 
-        <id name="id" type="integer" column="user_id">
+        <id name="id" type="integer" column="id">
             <generator strategy="AUTO" />
         </id>
 


### PR DESCRIPTION
I've seen that a PR has been made to change the original "id" to "user_id". However I think this is wrong, because when dealing with relationships, Doctrine assume that the target entity has an identifier whose name is "id", otherwise, you need to modify the mapping for the JoinColumn.

I think the name should map to what Doctrine does "out-of-the-box", that is to say considering the id is called "id".
