### PR TITLE
Updating dependency to doctrine-orm-module with the newly tagged versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "zendframework/zendframework": "2.*",
         "zf-commons/zfc-base": "dev-master",
         "zf-commons/zfc-user": "dev-master",
-        "doctrine/doctrine-orm-module": "dev-master"
+        "doctrine/doctrine-orm-module": "0.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Reverts a8fb27630c1c5ca106d5e8818b703ce523b4811c
