### PR TITLE
Correct alias for zfcuser_doctrine_em

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -38,7 +38,7 @@ class Module
     {
         return array(
             'aliases' => array(
-                'zfcuser_doctrine_em' => 'doctrine.entitymanager.orm_default',
+                'zfcuser_doctrine_em' => 'Doctrine\ORM\EntityManager',
 
             ),
             'factories' => array(


### PR DESCRIPTION
Alias no processed in  zf 2.2.4 and doctrine-module 0.8.*
pattern altered in version.
