### PR TITLE
Add dev-master alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "0.1.x-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
Some packages require the latest `dev-master` of this module, some a `0.*` version. Because there is no branch-alias (like in other ZF-Commons modules), this make this package uninstallable.
