### PR TITLE
Update ZfcUser version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zf-commons/zfc-user": "1.*",
+        "zf-commons/zfc-user": ">=0.1,<2.0",
         "doctrine/doctrine-orm-module": "0.*"
     },
     "extra": {


### PR DESCRIPTION
It is not that easy to migrate to ZfcUser 1.0!
Some modules like ScnSocialAuth are not compatible with ZfcUser 1.0
