### PR TITLE
Fix fatal error getEnableDefaultEntities #87

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -10,7 +10,7 @@ class Module
     {
         $app     = $e->getParam('application');
         $sm      = $app->getServiceManager();
-        $options = $sm->get('zfcuser_module_options');
+        $options = $sm->get('zfcuserdoctrine_module_options');
 
         // Add the default entity driver only if specified in configuration
         if ($options->getEnableDefaultEntities()) {

--- a/Module.php
+++ b/Module.php
@@ -12,8 +12,8 @@ class Module
         $sm      = $app->getServiceManager();
         $options = $sm->get('zfcuser_module_options');
 
-        // Add the default entity driver only if specified in configuration
-        if ($options->getEnableDefaultEntities()) {
+        // Add the default entity driver only if function is available(zfcUser1) && specified in configuration
+        if (method_exists($options, "getEnableDefaultEntities") && $options->getEnableDefaultEntities()) {
             $chain = $sm->get('doctrine.driver.orm_default');
             $chain->addDriver(new XmlDriver(__DIR__ . '/config/xml/zfcuserdoctrineorm'), 'ZfcUserDoctrineORM\Entity');
         }

--- a/Module.php
+++ b/Module.php
@@ -12,8 +12,8 @@ class Module
         $sm      = $app->getServiceManager();
         $options = $sm->get('zfcuser_module_options');
 
-        // Add the default entity driver only if function is available(zfcUser1) && specified in configuration
-        if (method_exists($options, "getEnableDefaultEntities") && $options->getEnableDefaultEntities()) {
+        // Add the default entity driver only if specified in configuration
+        if ($options->getEnableDefaultEntities()) {
             $chain = $sm->get('doctrine.driver.orm_default');
             $chain->addDriver(new XmlDriver(__DIR__ . '/config/xml/zfcuserdoctrineorm'), 'ZfcUserDoctrineORM\Entity');
         }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -14,4 +14,11 @@ return array(
             )
         )
     ),
+
+    'service_manager' => array(
+        'invokables' => array(),
+        'factories' => array(
+            'zfcuserdoctrine_module_options'                        => 'ZfcUserDoctrineORM\Factory\ModuleOptionsFactory',
+        ),
+    ),
 );

--- a/src/ZfcUserDoctrineORM/Factory/ModuleOptionsFactory.php
+++ b/src/ZfcUserDoctrineORM/Factory/ModuleOptionsFactory.php
@@ -1,0 +1,19 @@
+<?php
+namespace ZfcUserDoctrineORM\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfcUserDoctrineORM\Options\ModuleOptions;
+
+class ModuleOptionsFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $config = $serviceLocator->get('Config');
+
+        return new ModuleOptions(isset($config['zfcuser']) ? $config['zfcuser'] : array());
+    }
+}


### PR DESCRIPTION
Fix fatal error getEnableDefaultEntities:

Added a check to see if that function still exist (exist no more in dev-master opf zfcUser(zfcUser v2))
This check make the module compatible with zfcUser v1 and the dev-master(v2) untill now.