### PR TITLE
Add backticks to table name

### DIFF
--- a/config/xml/zfcuserdoctrineorm/ZfcUserDoctrineORM.Entity.User.dcm.xml
+++ b/config/xml/zfcuserdoctrineorm/ZfcUserDoctrineORM.Entity.User.dcm.xml
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
                   
-    <entity name="ZfcUserDoctrineORM\Entity\User" table="user">
+    <entity name="ZfcUserDoctrineORM\Entity\User" table="`user`">
 
     </entity>
 


### PR DESCRIPTION
In postgres the table user has a reserved meaning, so we need to add backticks to the table name so that doctrine is able to add quotes to the table name. See https://github.com/ZF-Commons/ZfcUserDoctrineORM/issues/77 and https://github.com/doctrine/dbal/pull/572 for some related issues