### PR TITLE
Move of factories from module.php to module.config.php

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -39,18 +39,6 @@ class Module
             'aliases' => array(
                 'zfcuser_doctrine_em' => 'Doctrine\ORM\EntityManager',
             ),
-            'factories' => array(
-                'zfcuser_module_options' => function ($sm) {
-                    $config = $sm->get('Configuration');
-                    return new Options\ModuleOptions(isset($config['zfcuser']) ? $config['zfcuser'] : array());
-                },
-                'zfcuser_user_mapper' => function ($sm) {
-                    return new \ZfcUserDoctrineORM\Mapper\User(
-                        $sm->get('zfcuser_doctrine_em'),
-                        $sm->get('zfcuser_module_options')
-                    );
-                },
-            ),
         );
     }
 

--- a/Module.php
+++ b/Module.php
@@ -3,13 +3,21 @@
 namespace ZfcUserDoctrineORM;
 
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Zend\EventManager\EventInterface;
+use Zend\ModuleManager\Feature;
+use Zend\ServiceManager\ServiceManager;
+use ZfcUserDoctrineORM\Options\ModuleOptions;
 
-class Module
+
+class Module implements Feature\AutoloaderProviderInterface, Feature\BootstrapListenerInterface
 {
-    public function onBootstrap($e)
+    public function onBootstrap(EventInterface $e)
     {
-        $app     = $e->getParam('application');
-        $sm      = $app->getServiceManager();
+        $app = $e->getParam('application');
+        /** @var ServiceManager $sm */
+        $sm = $app->getServiceManager();
+
+        /** @var ModuleOptions $options */
         $options = $sm->get('zfcuser_module_options');
 
         // Add the default entity driver only if specified in configuration
@@ -19,6 +27,9 @@ class Module
         }
     }
 
+    /**
+     * @return array
+     */
     public function getAutoloaderConfig()
     {
         return array(
@@ -29,15 +40,6 @@ class Module
                 'namespaces' => array(
                     __NAMESPACE__ => __DIR__ . '/src/' . __NAMESPACE__,
                 ),
-            ),
-        );
-    }
-
-    public function getServiceConfig()
-    {
-        return array(
-            'aliases' => array(
-                'zfcuser_doctrine_em' => 'Doctrine\ORM\EntityManager',
             ),
         );
     }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,17 +1,27 @@
 <?php
 return array(
-    'doctrine' => array(
+    'service_manager' => array(
+        'factories' => array(
+            'zfcuser_user_mapper'    => 'ZfcUserDoctrineORM\Factory\UserMapperFactory',
+            'zfcuser_module_options' => 'ZfcUserDoctrineORM\Factory\ModuleOptionsFactory',
+        ),
+        'aliases'   => array(
+            'zfcuser_register_form_hydrator' => 'zfcuser_user_hydrator',
+            'zfcuser_zend_db_adapter'        => 'Zend\Db\Adapter\Adapter',
+        ),
+    ),
+    'doctrine'        => array(
         'driver' => array(
             'zfcuser_entity' => array(
                 'class' => 'Doctrine\ORM\Mapping\Driver\XmlDriver',
-                'paths' => __DIR__ . '/xml/zfcuser'
+                'paths' => __DIR__ . '/xml/zfcuser',
             ),
 
             'orm_default' => array(
                 'drivers' => array(
-                    'ZfcUser\Entity'  => 'zfcuser_entity'
-                )
-            )
-        )
+                    'ZfcUser\Entity' => 'zfcuser_entity',
+                ),
+            ),
+        ),
     ),
 );

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -8,6 +8,7 @@ return array(
         'aliases'   => array(
             'zfcuser_register_form_hydrator' => 'zfcuser_user_hydrator',
             'zfcuser_zend_db_adapter'        => 'Zend\Db\Adapter\Adapter',
+            'zfcuser_doctrine_em'            => 'Doctrine\ORM\EntityManager',
         ),
     ),
     'doctrine'        => array(

--- a/src/ZfcUserDoctrineORM/Factory/ModuleOptionsFactory.php
+++ b/src/ZfcUserDoctrineORM/Factory/ModuleOptionsFactory.php
@@ -1,0 +1,19 @@
+<?php
+namespace ZfcUserDoctrineORM\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfcUserDoctrineORM\Options\ModuleOptions;
+
+class ModuleOptionsFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $config = $serviceLocator->get('Config');
+
+        return new ModuleOptions(isset($config['zfcuser']) ? $config['zfcuser'] : array());
+    }
+}

--- a/src/ZfcUserDoctrineORM/Factory/UserMapperFactory.php
+++ b/src/ZfcUserDoctrineORM/Factory/UserMapperFactory.php
@@ -1,0 +1,23 @@
+<?php
+namespace ZfcUserDoctrineORM\Factory;
+
+use Zend\Db;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\Stdlib\Hydrator;
+use ZfcUser\Mapper;
+use ZfcUser\Options;
+
+class UserMapperFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return new \ZfcUserDoctrineORM\Mapper\User(
+            $serviceLocator->get('zfcuser_doctrine_em'),
+            $serviceLocator->get('zfcuser_module_options')
+        );
+    }
+}


### PR DESCRIPTION
In ZfcUser many factories have moved from module.php to module.config.php.

This resulted in the unwanted effect that the factories in ZfcUserDoctrineORM are ignored. In this PR the two overwritten factories are created as separate factories.

