### PR TITLE
2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ZfcUserDoctrineORM
 ==================
-Version 0.1.1 Created by Kyle Spraggs and the ZF-Commons team
+Version 3.x Created by Kyle Spraggs and the ZF-Commons team
 
 Introduction
 ------------
@@ -20,6 +20,16 @@ Dependencies
 - [DoctrineModule](https://github.com/doctrine/DoctrineModule)
 - [DoctrineORMModule](https://github.com/doctrine/DoctrineORMModule)
 
+
+Versions
+--------
+Please use below table to figure out what version of ZfcUserDoctrineORM you should use.
+
+| ZfcUserDoctrineORM version | Supported ZfcUser version | Status                                      |
+|----------------------------|---------------------------|---------------------------------------------|
+| 1.x                        | 0.x, 1.x or 2.x           | Security-fixes only                         |
+| 2.x                        | 3.x                       | New features bug-fixes, security-fixes      |
+
 Installation
 ------------
 Set up Database Connection Settings for Doctrine ORM:
@@ -35,7 +45,6 @@ Set up your Modules in `config/application/application.config.php`, something li
     'modules' => array(
         'DoctrineModule',
         'DoctrineORMModule',
-        'ZfcBase',
         'ZfcUser',
         'ZfcUserDoctrineORM',
         'Application',

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,20 @@
             "name": "Kyle Spraggs",
             "email": "theman@spiffyjr.me",
             "homepage": "http://www.spiffyjr.me/"
+        },
+        {
+            "name": "Daniel Strøm",
+            "email": "danielss89@gmail.com"
         }
     ],
+    "extra": {
+        "zf": {
+            "module": "ZfcUserDoctrineORM"
+        }
+    },
     "require": {
         "php": ">=5.3.3",
-        "zf-commons/zfc-user": "*",
+        "zf-commons/zfc-user": "~3.0",
         "doctrine/doctrine-orm-module": "~1.0"
     },
     "autoload": {

--- a/src/ZfcUserDoctrineORM/Mapper/User.php
+++ b/src/ZfcUserDoctrineORM/Mapper/User.php
@@ -3,6 +3,7 @@
 namespace ZfcUserDoctrineORM\Mapper;
 
 use Doctrine\ORM\EntityManagerInterface;
+use ZfcUser\Entity\UserInterface;
 use ZfcUser\Mapper\User as ZfcUserMapper;
 use ZfcUserDoctrineORM\Options\ModuleOptions;
 use Zend\Stdlib\Hydrator\HydratorInterface;
@@ -46,12 +47,12 @@ class User extends ZfcUserMapper
         return $er->find($id);
     }
 
-    public function insert($entity, $tableName = null, HydratorInterface $hydrator = null)
+    public function insert(UserInterface $entity)
     {
         return $this->persist($entity);
     }
 
-    public function update($entity, $where = null, $tableName = null, HydratorInterface $hydrator = null)
+    public function update(UserInterface $entity)
     {
         return $this->persist($entity);
     }


### PR DESCRIPTION
Update ZfcUserDoctrineORM\Mapper\User.php to implement the ZfcUser\Mapper\UserInterface instead of extending the ZfcUser\Mapper\User 

<?php

namespace ZfcUserDoctrineORM\Mapper;

use Doctrine\ORM\EntityManagerInterface;
use ZfcUser\Entity\UserInterface;
use ZfcUser\Mapper\UserInterface as MapperInterface;
use ZfcUser\Mapper\User as ZfcUserMapper;
use ZfcUserDoctrineORM\Options\ModuleOptions;
use Zend\Stdlib\Hydrator\HydratorInterface;

class User implements MapperInterface
{
