### PR TITLE
Extend dependency to support DoctrineORMModule 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=5.3.3",
         "zf-commons/zfc-user": "*",
-        "doctrine/doctrine-orm-module": "~1.0"
+        "doctrine/doctrine-orm-module": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Keeping the v1.x for BC while allowing use of v2.x. It seems there are no BC breaking changes from v1 to v2. 