### PR TITLE
Extend dependency to support DoctrineORMModule 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=5.3.3",
         "zf-commons/zfc-user": "*",
-        "doctrine/doctrine-orm-module": "~1.0"
+        "doctrine/doctrine-orm-module": "^2.0 || ^3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Keeping the v2.x for BC while allowing use of v3.x